### PR TITLE
Grammatical typo fix

### DIFF
--- a/docs/akka-http/10.1.14/security/2021-02-24-incorrect-handling-of-Transfer-Encoding-header.html
+++ b/docs/akka-http/10.1.14/security/2021-02-24-incorrect-handling-of-Transfer-Encoding-header.html
@@ -264,7 +264,7 @@ Version 10.1.14
 <p>Based on our assessment, the CVSS score of this vulnerability is 4.2 (Medium), based on vector <a href="https://nvd.nist.gov/vuln-metrics/cvss/v3-calculator?vector=AV:N/AC:H/PR:N/UI:N/S:U/C:L/I:L/A:N/E:U/RL:O/RC:C&version=3.1">(AV:N/AC:H/PR:N/UI:N/S:U/C:L/I:L/A:N/E:U/RL:O/RC:C)</a>.</p>
 <h2><a href="#impact" name="impact" class="anchor"><span class="anchor-link"></span></a>Impact</h2>
 <p>A vulnerable Akka HTTP server will accept a malformed message as described above and hand it over to the user. If the user application proxies this message to another server unchanged and that server also accepts that message but interprets it as two HTTP messages, the second message has reached the second server without having been inspected by the proxy.</p>
-<p>Note that Akka HTTP itself does currently not provide functionality to proxy requests to other servers (but it&rsquo;s easy to build).</p>
+<p>Note that Akka HTTP itself currently does not provide functionality to proxy requests to other servers (but it&rsquo;s easy to build).</p>
 <p>In summary, these conditions must be true for an application to be vulnerable:</p>
 <ul>
   <li>use a vulnerable version of Akka HTTP</li>

--- a/docs/akka-http/10.2.4/security/2021-02-24-incorrect-handling-of-Transfer-Encoding-header.html
+++ b/docs/akka-http/10.2.4/security/2021-02-24-incorrect-handling-of-Transfer-Encoding-header.html
@@ -265,7 +265,7 @@ Version 10.2.4
 <p>Based on our assessment, the CVSS score of this vulnerability is 4.2 (Medium), based on vector <a href="https://nvd.nist.gov/vuln-metrics/cvss/v3-calculator?vector=AV:N/AC:H/PR:N/UI:N/S:U/C:L/I:L/A:N/E:U/RL:O/RC:C&version=3.1">(AV:N/AC:H/PR:N/UI:N/S:U/C:L/I:L/A:N/E:U/RL:O/RC:C)</a>.</p>
 <h2><a href="#impact" name="impact" class="anchor"><span class="anchor-link"></span></a>Impact</h2>
 <p>A vulnerable Akka HTTP server will accept a malformed message as described above and hand it over to the user. If the user application proxies this message to another server unchanged and that server also accepts that message but interprets it as two HTTP messages, the second message has reached the second server without having been inspected by the proxy.</p>
-<p>Note that Akka HTTP itself does currently not provide functionality to proxy requests to other servers (but it&rsquo;s easy to build).</p>
+<p>Note that Akka HTTP itself currently does not provide functionality to proxy requests to other servers (but it&rsquo;s easy to build).</p>
 <p>In summary, these conditions must be true for an application to be vulnerable:</p>
 <ul>
   <li>use a vulnerable version of Akka HTTP</li>

--- a/docs/akka/1.1.3/_sources/java/remote-actors.txt
+++ b/docs/akka/1.1.3/_sources/java/remote-actors.txt
@@ -481,7 +481,7 @@ You can configure it like this:
 Code provisioning
 -----------------
 
-Akka does currently not support automatic code provisioning but requires you to have the remote actor class files available on both the "client" the "server" nodes.
+Akka currently does not support automatic code provisioning but requires you to have the remote actor class files available on both the "client" the "server" nodes.
 This is something that will be addressed soon. Until then, sorry for the inconvenience.
 
 Subscribe to Remote Client events

--- a/docs/akka/1.1.3/_sources/scala/remote-actors.txt
+++ b/docs/akka/1.1.3/_sources/scala/remote-actors.txt
@@ -536,7 +536,7 @@ You can configure it like this:
 Code provisioning
 -----------------
 
-Akka does currently not support automatic code provisioning but requires you to have the remote actor class files available on both the "client" the "server" nodes.
+Akka currently does not support automatic code provisioning but requires you to have the remote actor class files available on both the "client" the "server" nodes.
 This is something that will be addressed soon. Until then, sorry for the inconvenience.
 
 Subscribe to Remote Client events

--- a/docs/akka/1.1.3/java/remote-actors.html
+++ b/docs/akka/1.1.3/java/remote-actors.html
@@ -485,7 +485,7 @@ Please note that firewalled clients won&#8217;t work right now. [2011-01-05]</p>
 </div>
 <div class="section" id="code-provisioning">
 <h2><a class="toc-backref" href="#id28">Code provisioning</a><a class="headerlink" href="#code-provisioning" title="Permalink to this headline">¶</a></h2>
-<p>Akka does currently not support automatic code provisioning but requires you to have the remote actor class files available on both the &#8220;client&#8221; the &#8220;server&#8221; nodes.
+<p>Akka currently does not support automatic code provisioning but requires you to have the remote actor class files available on both the &#8220;client&#8221; the &#8220;server&#8221; nodes.
 This is something that will be addressed soon. Until then, sorry for the inconvenience.</p>
 </div>
 <div class="section" id="subscribe-to-remote-client-events">

--- a/docs/akka/1.1.3/scala/remote-actors.html
+++ b/docs/akka/1.1.3/scala/remote-actors.html
@@ -538,7 +538,7 @@ actor.registerUser(…)</pre>
 </div>
 <div class="section" id="code-provisioning">
 <h2><a class="toc-backref" href="#id30">Code provisioning</a><a class="headerlink" href="#code-provisioning" title="Permalink to this headline">¶</a></h2>
-<p>Akka does currently not support automatic code provisioning but requires you to have the remote actor class files available on both the &#8220;client&#8221; the &#8220;server&#8221; nodes.
+<p>Akka currently does not support automatic code provisioning but requires you to have the remote actor class files available on both the &#8220;client&#8221; the &#8220;server&#8221; nodes.
 This is something that will be addressed soon. Until then, sorry for the inconvenience.</p>
 </div>
 <div class="section" id="subscribe-to-remote-client-events">

--- a/docs/akka/1.2/_sources/java/remote-actors.txt
+++ b/docs/akka/1.2/_sources/java/remote-actors.txt
@@ -481,7 +481,7 @@ You can configure it like this:
 Code provisioning
 -----------------
 
-Akka does currently not support automatic code provisioning but requires you to have the remote actor class files available on both the "client" the "server" nodes.
+Akka currently does not support automatic code provisioning but requires you to have the remote actor class files available on both the "client" the "server" nodes.
 This is something that will be addressed soon. Until then, sorry for the inconvenience.
 
 Subscribe to Remote Client events

--- a/docs/akka/1.2/_sources/scala/remote-actors.txt
+++ b/docs/akka/1.2/_sources/scala/remote-actors.txt
@@ -536,7 +536,7 @@ You can configure it like this:
 Code provisioning
 -----------------
 
-Akka does currently not support automatic code provisioning but requires you to have the remote actor class files available on both the "client" the "server" nodes.
+Akka currently does not support automatic code provisioning but requires you to have the remote actor class files available on both the "client" the "server" nodes.
 This is something that will be addressed soon. Until then, sorry for the inconvenience.
 
 Subscribe to Remote Client events

--- a/docs/akka/1.2/java/remote-actors.html
+++ b/docs/akka/1.2/java/remote-actors.html
@@ -485,7 +485,7 @@ Please note that firewalled clients won&#8217;t work right now. [2011-01-05]</p>
 </div>
 <div class="section" id="code-provisioning">
 <h2><a class="toc-backref" href="#id28">Code provisioning</a><a class="headerlink" href="#code-provisioning" title="Permalink to this headline">¶</a></h2>
-<p>Akka does currently not support automatic code provisioning but requires you to have the remote actor class files available on both the &#8220;client&#8221; the &#8220;server&#8221; nodes.
+<p>Akka currently does not support automatic code provisioning but requires you to have the remote actor class files available on both the &#8220;client&#8221; the &#8220;server&#8221; nodes.
 This is something that will be addressed soon. Until then, sorry for the inconvenience.</p>
 </div>
 <div class="section" id="subscribe-to-remote-client-events">

--- a/docs/akka/1.2/scala/remote-actors.html
+++ b/docs/akka/1.2/scala/remote-actors.html
@@ -538,7 +538,7 @@ actor.registerUser(…)</pre>
 </div>
 <div class="section" id="code-provisioning">
 <h2><a class="toc-backref" href="#id30">Code provisioning</a><a class="headerlink" href="#code-provisioning" title="Permalink to this headline">¶</a></h2>
-<p>Akka does currently not support automatic code provisioning but requires you to have the remote actor class files available on both the &#8220;client&#8221; the &#8220;server&#8221; nodes.
+<p>Akka currently does not support automatic code provisioning but requires you to have the remote actor class files available on both the &#8220;client&#8221; the &#8220;server&#8221; nodes.
 This is something that will be addressed soon. Until then, sorry for the inconvenience.</p>
 </div>
 <div class="section" id="subscribe-to-remote-client-events">

--- a/docs/akka/1.3.1/_sources/java/remote-actors.txt
+++ b/docs/akka/1.3.1/_sources/java/remote-actors.txt
@@ -479,7 +479,7 @@ You can configure it like this:
 Code provisioning
 -----------------
 
-Akka does currently not support automatic code provisioning but requires you to have the remote actor class files available on both the "client" the "server" nodes.
+Akka currently does not support automatic code provisioning but requires you to have the remote actor class files available on both the "client" the "server" nodes.
 This is something that will be addressed soon. Until then, sorry for the inconvenience.
 
 Subscribe to Remote Client events

--- a/docs/akka/1.3.1/_sources/scala/remote-actors.txt
+++ b/docs/akka/1.3.1/_sources/scala/remote-actors.txt
@@ -533,7 +533,7 @@ You can configure it like this:
 Code provisioning
 -----------------
 
-Akka does currently not support automatic code provisioning but requires you to have the remote actor class files available on both the "client" the "server" nodes.
+Akka currently does not support automatic code provisioning but requires you to have the remote actor class files available on both the "client" the "server" nodes.
 This is something that will be addressed soon. Until then, sorry for the inconvenience.
 
 Subscribe to Remote Client events

--- a/docs/akka/1.3.1/java/remote-actors.html
+++ b/docs/akka/1.3.1/java/remote-actors.html
@@ -474,7 +474,7 @@ Please note that firewalled clients won&#8217;t work right now. [2011-01-05]</p>
 </div>
 <div class="section" id="code-provisioning">
 <h2>Code provisioning</h2>
-<p>Akka does currently not support automatic code provisioning but requires you to have the remote actor class files available on both the &#8220;client&#8221; the &#8220;server&#8221; nodes.
+<p>Akka currently does not support automatic code provisioning but requires you to have the remote actor class files available on both the &#8220;client&#8221; the &#8220;server&#8221; nodes.
 This is something that will be addressed soon. Until then, sorry for the inconvenience.</p>
 </div>
 <div class="section" id="subscribe-to-remote-client-events">

--- a/docs/akka/1.3.1/scala/remote-actors.html
+++ b/docs/akka/1.3.1/scala/remote-actors.html
@@ -523,7 +523,7 @@ actor.registerUser(…)</pre>
 </div>
 <div class="section" id="code-provisioning">
 <h2>Code provisioning</h2>
-<p>Akka does currently not support automatic code provisioning but requires you to have the remote actor class files available on both the &#8220;client&#8221; the &#8220;server&#8221; nodes.
+<p>Akka currently does not support automatic code provisioning but requires you to have the remote actor class files available on both the &#8220;client&#8221; the &#8220;server&#8221; nodes.
 This is something that will be addressed soon. Until then, sorry for the inconvenience.</p>
 </div>
 <div class="section" id="subscribe-to-remote-client-events">


### PR DESCRIPTION
This is a simple documentation fix for a change from "does currently not" to "currently does not"
